### PR TITLE
Adds a registry of types of data sources

### DIFF
--- a/src/org/linkeddatafragments/datasource/DataSourceFactory.java
+++ b/src/org/linkeddatafragments/datasource/DataSourceFactory.java
@@ -1,8 +1,6 @@
 package org.linkeddatafragments.datasource;
 
 import com.google.gson.JsonObject;
-import java.io.File;
-import java.io.IOException;
 import org.linkeddatafragments.exceptions.DataSourceException;
 import org.linkeddatafragments.exceptions.UnknownDataSourceTypeException;
 
@@ -10,11 +8,9 @@ import org.linkeddatafragments.exceptions.UnknownDataSourceTypeException;
  *
  * @author Miel Vander Sande
  * @author Bart Hanssens
+ * @author <a href="http://olafhartig.de">Olaf Hartig</a>
  */
 public class DataSourceFactory {
-    public final static String HDT = "HdtDatasource";
-    public final static String JENA_TDB = "JenaTDBDatasource";
-
     /**
      * Create a datasource using a JSON config
      * 
@@ -25,28 +21,15 @@ public class DataSourceFactory {
     public static IDataSource create(JsonObject config) throws DataSourceException {
         String title = config.getAsJsonPrimitive("title").getAsString();
         String description = config.getAsJsonPrimitive("description").getAsString();
-        String type = config.getAsJsonPrimitive("type").getAsString();
+        String typeName = config.getAsJsonPrimitive("type").getAsString();
         
         JsonObject settings = config.getAsJsonObject("settings");
 
-        switch (type) {
-            case HDT:
-                try {
-                    File file = new File(settings.getAsJsonPrimitive("file").getAsString());
-                    return new HdtDataSource(title, description, file.getAbsolutePath());
-                } catch (IOException ex) {
-                    throw new DataSourceException(ex);
-                }
-                
-            case JENA_TDB:                
-                File file = new File(settings.getAsJsonPrimitive("directory").getAsString());
-                return new JenaTDBDataSource(title, description, file);
-                
-            default:
-                throw new UnknownDataSourceTypeException(type);
+        final IDataSourceType type = DataSourceTypesRegistry.getType(typeName);
+        if ( type == null )
+            throw new UnknownDataSourceTypeException(typeName);
 
-        }
-
+        return type.createDataSource( title, description, settings );
     }
 
 }

--- a/src/org/linkeddatafragments/datasource/DataSourceTypesRegistry.java
+++ b/src/org/linkeddatafragments/datasource/DataSourceTypesRegistry.java
@@ -1,0 +1,36 @@
+package org.linkeddatafragments.datasource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A registry of {@link IDataSourceType}s.
+ *
+ * @author <a href="http://olafhartig.de">Olaf Hartig</a>
+ */
+public class DataSourceTypesRegistry
+{
+    private static Map<String, IDataSourceType> registry =
+                                        new HashMap<String, IDataSourceType>();
+
+    public static synchronized IDataSourceType getType( final String typeName )
+    {
+        return registry.get( typeName );
+    }
+
+    public static synchronized boolean isRegistered( final String typeName )
+    {
+        return registry.containsKey( typeName );
+    }
+
+    public static synchronized void register( final String typeName,
+                                              final IDataSourceType type )
+    {
+        if ( registry.containsKey(typeName) ) {
+            throw new IllegalArgumentException( "The registry already " +
+                       "contains a type with the name '" + typeName + "'." );
+        }
+        registry.put( typeName, type );
+    }
+
+}

--- a/src/org/linkeddatafragments/datasource/HdtDataSourceType.java
+++ b/src/org/linkeddatafragments/datasource/HdtDataSourceType.java
@@ -1,0 +1,42 @@
+package org.linkeddatafragments.datasource;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.linkeddatafragments.exceptions.DataSourceException;
+
+import com.google.gson.JsonObject;
+
+/**
+ * The type of HDT-backed Triple Pattern Fragment data sources.
+ *
+ * @author <a href="http://olafhartig.de">Olaf Hartig</a>
+ */
+public class HdtDataSourceType implements IDataSourceType
+{
+    public static final String TYPE_NAME = "HdtDatasource";
+
+    public static void register() {
+        if ( ! DataSourceTypesRegistry.isRegistered(TYPE_NAME) ) {
+            DataSourceTypesRegistry.register( TYPE_NAME,
+                                              new HdtDataSourceType() );
+        }
+    }
+
+    @Override
+    public IDataSource createDataSource( final String title,
+                                         final String description,
+                                         final JsonObject settings )
+                                                     throws DataSourceException
+    {
+        final String fname = settings.getAsJsonPrimitive("file").getAsString();
+        final File file = new File( fname );
+        
+        try {
+            return new HdtDataSource(title, description, file.getAbsolutePath());
+        } catch (IOException ex) {
+            throw new DataSourceException(ex);
+        }
+    }
+
+}

--- a/src/org/linkeddatafragments/datasource/IDataSourceType.java
+++ b/src/org/linkeddatafragments/datasource/IDataSourceType.java
@@ -1,0 +1,32 @@
+package org.linkeddatafragments.datasource;
+
+import org.linkeddatafragments.exceptions.DataSourceException;
+
+import com.google.gson.JsonObject;
+
+/**
+ * Represents types of {@link IDataSource}s that can be used to provide some
+ * Linked Data Fragments interface.
+ *
+ * @author <a href="http://olafhartig.de">Olaf Hartig</a>
+ */
+public interface IDataSourceType
+{
+    /**
+     * Creates a data source of this type.
+     * 
+     * @param title
+     *        The title of the data source (as given in the config file).
+     * 
+     * @param description
+     *        The description of the data source (as given in the config file).
+     *
+     * @param settings
+     *        The properties of the data source to be created; usually, these
+     *        properties are given in the config file of the LDF server. 
+     */
+    IDataSource createDataSource( final String title,
+                                  final String description,
+                                  final JsonObject settings )
+                                                    throws DataSourceException;
+}

--- a/src/org/linkeddatafragments/datasource/JenaTDBDataSourceType.java
+++ b/src/org/linkeddatafragments/datasource/JenaTDBDataSourceType.java
@@ -1,0 +1,42 @@
+package org.linkeddatafragments.datasource;
+
+import java.io.File;
+
+import org.linkeddatafragments.exceptions.DataSourceException;
+
+import com.google.gson.JsonObject;
+
+/**
+ * The type of Triple Pattern Fragment data sources that are backed by
+ * a Jena TDB instance.
+ *
+ * @author <a href="http://olafhartig.de">Olaf Hartig</a>
+ */
+public class JenaTDBDataSourceType implements IDataSourceType
+{
+    public static final String TYPE_NAME = "JenaTDBDatasource";
+
+    public static void register() {
+        if ( ! DataSourceTypesRegistry.isRegistered(TYPE_NAME) ) {
+            DataSourceTypesRegistry.register( TYPE_NAME,
+                                              new JenaTDBDataSourceType() );
+        }
+    }
+
+    @Override
+    public IDataSource createDataSource( final String title,
+                                         final String description,
+                                         final JsonObject settings )
+                                                     throws DataSourceException
+    {
+        final String dname = settings.getAsJsonPrimitive("directory").getAsString();
+        final File dir = new File( dname );
+
+        try {
+            return new JenaTDBDataSource(title, description, dir);
+        } catch (Exception ex) {
+            throw new DataSourceException(ex);
+        }
+    }
+
+}

--- a/src/org/linkeddatafragments/servlet/TriplePatternFragmentServlet.java
+++ b/src/org/linkeddatafragments/servlet/TriplePatternFragmentServlet.java
@@ -31,8 +31,10 @@ import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFLanguages;
 import org.linkeddatafragments.config.ConfigReader;
 import org.linkeddatafragments.datasource.DataSourceFactory;
+import org.linkeddatafragments.datasource.HdtDataSourceType;
 import org.linkeddatafragments.datasource.IDataSource;
 import org.linkeddatafragments.datasource.IndexDataSource;
+import org.linkeddatafragments.datasource.JenaTDBDataSourceType;
 import org.linkeddatafragments.datasource.TriplePatternFragment;
 import org.linkeddatafragments.exceptions.DataSourceException;
 import org.linkeddatafragments.util.CommonResources;
@@ -63,6 +65,11 @@ public class TriplePatternFragmentServlet extends HttpServlet {
     private ConfigReader config;
     private final HashMap<String, IDataSource> dataSources = new HashMap<>();
     private final Collection<String> mimeTypes = new ArrayList<>();
+
+    public TriplePatternFragmentServlet() {
+        HdtDataSourceType.register();
+        JenaTDBDataSourceType.register();
+    }
 
     private File getConfigFile(ServletConfig config) throws IOException {
         String path = config.getServletContext().getRealPath("/");

--- a/src/test/java/org/linkeddatafragments/datasource/JenaTDBDataSourceTest.java
+++ b/src/test/java/org/linkeddatafragments/datasource/JenaTDBDataSourceTest.java
@@ -20,6 +20,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.linkeddatafragments.datasource.DataSourceFactory;
 import org.linkeddatafragments.datasource.IDataSource;
+import org.linkeddatafragments.datasource.JenaTDBDataSourceType;
 import org.linkeddatafragments.datasource.TriplePatternFragment;
 
 /**
@@ -35,6 +36,8 @@ public class JenaTDBDataSourceTest {
             
     @BeforeClass
     public static void setUpClass() throws Exception {
+        JenaTDBDataSourceType.register();
+
         String tmpdir = System.getProperty("java.io.tmpdir");
         jena = new File(tmpdir, "ldf-jena-test");
         jena.mkdir();
@@ -44,7 +47,7 @@ public class JenaTDBDataSourceTest {
         JsonObject config = new JsonObject();
         config.addProperty("title", "jena test");
         config.addProperty("description", "jena tdb test");
-        config.addProperty("type", DataSourceFactory.JENA_TDB);
+        config.addProperty("type", JenaTDBDataSourceType.TYPE_NAME);
         
         JsonObject settings = new JsonObject();
         settings.addProperty("directory", jena.getAbsolutePath());


### PR DESCRIPTION
Currently, the notion of a type of data sources (e.g., HDT-backed data sources) is implicit and the types that are supported are fixed. This PR introduces more flexibility by making the following two contributions:

1. it makes the notion of data source types explicit (see `IDataSourceType`), and
2. it adds a registry of such types (see `DataSourceTypesRegistry`) and integrates this registry into the existing code base (see how `DataSourceFactory` uses the registry now).