### PR TITLE
Correction for setting up a reverse proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,21 @@
-.settings
-target
+# Eclipse
+.classpath
+.project
+.settings/
+
+# Intellij
+.idea/
+*.iml
+*.iws
+
+# Mac
+.DS_Store
+
+# Maven
+log/
+target/
+
 ldf-server.json
 /data/
 /nbproject/
+

--- a/src/main/resources/views/index.ftl.html
+++ b/src/main/resources/views/index.ftl.html
@@ -7,7 +7,7 @@
   <dl class="datasets">
       <#if datasources??>
     <#list datasources?keys as datasourceName>
-        <dt><a href="/${datasourceName}">${datasources[datasourceName].getTitle() }</a></dt>
+        <dt><a href="${datasourceName}">${datasources[datasourceName].getTitle() }</a></dt>
         <dd>${ datasources[datasourceName].getDescription()!"" }</dd>
     </#list>
     </#if>


### PR DESCRIPTION
The file index.ftl.html contains an absolute link that failed to proxy the data in a subfolder.
I've added some rules for Eclipse and IntelliJ to the gitignore file, too.