### PR TITLE
Add classes so they can be used as "clean" dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,7 @@
                 <configuration>
                     <warSourceDirectory>WebContent</warSourceDirectory>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
+                    <attachClasses>true</attachClasses>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This will allow to make clean dependency on ldfserver without pulling in extra classes like ones causing https://github.com/LinkedDataFragments/Server.Java/issues/39
