### PR TITLE
Fix template issues when no triples found

### DIFF
--- a/src/main/resources/views/fragment.ftl.html
+++ b/src/main/resources/views/fragment.ftl.html
@@ -36,9 +36,9 @@
   <@pageLinks/>
 <#else>
   <p>
-    <%= datasource.getTitle() %> contains
+    ${datasource.getTitle()} contains
     <span property="void:triples hydra:totalItems" datatype="xsd:integer" content="0">
-      no <#if totalEstimate > 0 >more</#if>
+      no <#if (totalEstimate > 0) >more</#if>
     </span>
     triples that match this pattern.
   </p>


### PR DESCRIPTION
Correct access of datasource.getTitle()

Template error in check of totalEstimate (early <#if> closure)