### PR TITLE
Change to IndexRequestProcessorForTPFs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,12 @@
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.10</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/org/linkeddatafragments/datasource/index/IndexRequestProcessorForTPFs.java
+++ b/src/main/java/org/linkeddatafragments/datasource/index/IndexRequestProcessorForTPFs.java
@@ -55,7 +55,7 @@ public class IndexRequestProcessorForTPFs
 
             Resource datasourceUrl = new ResourceImpl(baseUrl + "/" + datasourceName);
 
-            model.add(datasourceUrl, new PropertyImpl(RDF + "type"), VOID + "Dataset");
+            model.add(datasourceUrl, new PropertyImpl(RDF + "type"), new ResourceImpl(VOID + "Dataset"));
             model.add(datasourceUrl, new PropertyImpl(RDFS + "label"), datasource.getTitle());
             model.add(datasourceUrl, new PropertyImpl(DC + "title"), datasource.getTitle());
             model.add(datasourceUrl, new PropertyImpl(DC + "description"), datasource.getDescription());

--- a/src/test/java/org/linkeddatafragments/test/datasource/IndexRequestProcessorForTPFsTest.java
+++ b/src/test/java/org/linkeddatafragments/test/datasource/IndexRequestProcessorForTPFsTest.java
@@ -1,0 +1,114 @@
+package org.linkeddatafragments.datasource;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.StmtIterator;
+import org.junit.Assert;
+import org.junit.Test;
+import org.linkeddatafragments.datasource.IDataSource;
+import org.linkeddatafragments.datasource.IFragmentRequestProcessor;
+import org.linkeddatafragments.datasource.index.IndexRequestProcessorForTPFs;
+import org.linkeddatafragments.fragments.IFragmentRequestParser;
+import org.linkeddatafragments.fragments.ILinkedDataFragment;
+import org.linkeddatafragments.fragments.tpf.ITriplePatternFragmentRequest;
+import org.linkeddatafragments.fragments.tpf.TriplePatternElementFactory;
+import org.linkeddatafragments.fragments.tpf.TriplePatternFragmentRequestImpl;
+
+/**
+ * Test cases for the IndexRequestProcessorForTPFs
+ *
+ * @author Lars G. Svensson
+ */
+public class IndexRequestProcessorForTPFsTest {
+
+	static class TestIndexRequestProcessor extends IndexRequestProcessorForTPFs {
+		TestIndexRequestProcessor(final String baseUrl,
+				final HashMap<String, IDataSource> datasources) {
+			super(baseUrl, datasources);
+		}
+
+		@Override
+		protected TestWorker getTPFSpecificWorker(
+				final ITriplePatternFragmentRequest<RDFNode, String, String> request)
+				throws IllegalArgumentException {
+			return new TestWorker(request);
+		}
+
+		class TestWorker extends IndexRequestProcessorForTPFs.Worker {
+			public TestWorker(
+					final ITriplePatternFragmentRequest<RDFNode, String, String> req) {
+				super(req);
+			}
+		}
+	}
+
+	/**
+	 * Check that the type void:Dataset is returned as a URI and not as a
+	 * literal
+	 */
+	@Test
+	public void shouldGiveVoidDatasetAsAURI() {
+		final IDataSource datasource = new IDataSource() {
+			@Override
+			public String getDescription() {
+				return "This is a dummy datasource";
+			};
+
+			@Override
+			public IFragmentRequestParser getRequestParser() {
+				return null;
+			}
+
+			@Override
+			public IFragmentRequestProcessor getRequestProcessor() {
+				return null;
+			}
+
+			@Override
+			public String getTitle() {
+				return "Dummy Dataource";
+			}
+
+			@Override
+			public void close() {
+				// does nothing
+			}
+		};
+		final HashMap<String, IDataSource> datasources = new HashMap<String, IDataSource>();
+		datasources.put("dummy", datasource);
+		final String baseUrl = "dummy";
+		final TestIndexRequestProcessor processor = new TestIndexRequestProcessor(
+				baseUrl, datasources);
+		final TriplePatternElementFactory<RDFNode, String, String> factory = new TriplePatternElementFactory<RDFNode, String, String>();
+		final ITriplePatternFragmentRequest<RDFNode, String, String> request = new TriplePatternFragmentRequestImpl<RDFNode, String, String>(
+				null, "dummy", false, 1, factory.createUnspecifiedVariable(),
+				factory.createUnspecifiedVariable(),
+				factory.createUnspecifiedVariable());
+		final TestIndexRequestProcessor.TestWorker worker = processor
+				.getTPFSpecificWorker(request);
+		final ILinkedDataFragment fragment = worker.createRequestedFragment();
+		final StmtIterator iterator = fragment.getTriples();
+		final Collection<Statement> statements = new ArrayList<Statement>();
+		while (iterator.hasNext()) {
+			statements.add(iterator.next());
+		}
+
+		final Resource subject = ResourceFactory.createResource("dummy/dummy");
+		final Property predicate = ResourceFactory
+				.createProperty("http://www.w3.org/1999/02/22-rdf-syntax-ns#type");
+		final Resource object = ResourceFactory
+				.createResource("http://rdfs.org/ns/void#Dataset");
+		final Statement expected = ResourceFactory.createStatement(subject,
+				predicate, object);
+		Assert.assertTrue("triple not contained in model",
+				statements.contains(expected));
+		processor.close();
+	}
+}


### PR DESCRIPTION
When querying the server for metadata about all datasets, the triple typing the dataset as a `void:Dataset` gives the object as a literal (`"http://rdfs.org/ns/void#Dataset"`) and not as a URI (`<http://rdfs.org/ns/void#Dataset>`). This PR includes a fix, a test case and includes a dependency on JUnit in pom.xml.